### PR TITLE
`build.sh`: Only install Gnome extension if `gnome-shell` is installed

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -98,7 +98,7 @@ xvfb-run -a -- sharun l -p -v -e -s -k /usr/bin/gnome-pomodoro
 
 echo '#!/bin/sh
 CURRENTDIR="$(cd "${0%/*}" && echo "$PWD")"
-if command -v gnome-shell &> /dev/null; then
+if command -v gnome-shell 1>/dev/null; then
   DATADIR="${XDG_DATA_HOME:-$HOME/.local/share}"
   mkdir -p "${DATADIR}"/gnome-shell/extensions
   cp -r "${CURRENTDIR}"/pomodoro@arun.codito.in "${DATADIR}"/gnome-shell/extensions

--- a/build.sh
+++ b/build.sh
@@ -98,10 +98,12 @@ xvfb-run -a -- sharun l -p -v -e -s -k /usr/bin/gnome-pomodoro
 
 echo '#!/bin/sh
 CURRENTDIR="$(cd "${0%/*}" && echo "$PWD")"
-DATADIR="${XDG_DATA_HOME:-$HOME/.local/share}"
-mkdir -p "${DATADIR}"/gnome-shell/extensions
-cp -r "${CURRENTDIR}"/pomodoro@arun.codito.in "${DATADIR}"/gnome-shell/extensions
-sed -i -e "s|/usr|${CURRENTDIR}|g" "${DATADIR}"/gnome-shell/extensions/pomodoro@arun.codito.in/config.js
+if command -v gnome-shell &> /dev/null; then
+  DATADIR="${XDG_DATA_HOME:-$HOME/.local/share}"
+  mkdir -p "${DATADIR}"/gnome-shell/extensions
+  cp -r "${CURRENTDIR}"/pomodoro@arun.codito.in "${DATADIR}"/gnome-shell/extensions
+  sed -i -e "s|/usr|${CURRENTDIR}|g" "${DATADIR}"/gnome-shell/extensions/pomodoro@arun.codito.in/config.js
+fi
 exec "${CURRENTDIR}"/bin/gnome-pomodoro "${@}"' >./AppRun
 
 chmod a+x ./AppRun


### PR DESCRIPTION
This way, extension doesn't install in other unsupported desktop environments.